### PR TITLE
Register a restore fn for through() spies

### DIFF
--- a/bond.coffee
+++ b/bond.coffee
@@ -115,6 +115,7 @@ bond = (obj, property) ->
         callback(returnValues...)
 
   through = ->
+    registerRestore()
     obj[property] = createThroughSpy(previous, this)
     obj[property]
 

--- a/lib/bond.js
+++ b/lib/bond.js
@@ -148,6 +148,7 @@ void function () {
       });
     };
     through = function () {
+      registerRestore();
       obj[property] = createThroughSpy(previous, this);
       return obj[property];
     };


### PR DESCRIPTION
It seems like `through()` spies are never deregistered, which can cause them to retain their call counts.  Failing tests like ```1 != 2``` could be related to this eg https://circleci.com/gh/hellodigit/digit/12384

The other spies are deregistering fine, like `asyncReturn` and `to`.